### PR TITLE
Add sphinx workflow for documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+# This workflow builds and deploys Sphinx documentation to the gh-pages branch
+# It builds when a tag is _released_ (meaning not a prerelease).
+
+name: Build and Deploy Sphinx Docs
+
+
+on:
+  release:
+    types: [released]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# follows https://github.com/marketplace/actions/deploy-to-github-pages
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      # Set up the python environment.
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      
+      # Set up dependencies.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx sphinx_rtd_theme
+
+      # Build the documentation
+      - name: Build Docs
+        run: |
+          make documentation
+      
+      # Use https://github.com/marketplace/actions/deploy-to-github-pages to deploy docs.
+      - name: Deploy Docs
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/html
+          CLEAN: true


### PR DESCRIPTION
Builds and deploys docs on package release.

Fixes #1 

Changes proposed in this pull request:
- This is the final piece of CI/CD, at least for now. Adds a workflow that builds and deploys the sphinx documentation to the `gh-pages` branch whenever there is a release (but not a prerelease).


@ExpediaGroup/map-maker-committers
